### PR TITLE
make populated data consistent

### DIFF
--- a/helper/populate_db.py
+++ b/helper/populate_db.py
@@ -39,6 +39,10 @@ def populate_db_with_test_data(session):
         ClosedUserAnswers(users_nicedayuid=40121, value=1, question='paevaluation', datetime=datetime.now().astimezone(tz_nl)),
         DialogAnswers(users_nicedayuid=38527, answer='lekker stoer eng', question_id=1,
                       datetime=datetime.now().astimezone(tz_nl)),
+        DialogAnswers(users_nicedayuid=40121, answer='lekker leuk eng', question_id=1,
+                      datetime=datetime.now().astimezone(tz_nl)),
+        DialogAnswers(users_nicedayuid=40121, answer='eng leuk stoer', question_id=3,
+                      datetime=datetime.now().astimezone(tz_nl)),
         UserInterventionState(users_nicedayuid=40121, intervention_component="future_self_dialog", last_time=datetime.now().astimezone(tz_nl), last_part=1)
     ]
     [session.merge(obj) for obj in objects]


### PR DESCRIPTION
If the user intervention state says that part 1 of future self dialog has been completed, there should be some saved data for the smoker and mover words in the answers table. 

I need this for the future self repetition.