### PR TITLE
Issue283 robust db migrations

### DIFF
--- a/dbschema/migrations/env.py
+++ b/dbschema/migrations/env.py
@@ -25,7 +25,6 @@ currentdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(currentdir)
 sys.path.append(parentdir)
 target_metadata = Base.metadata
-print(target_metadata.tables)
 
 
 # other values from the config, defined by the needs of env.py,
@@ -85,11 +84,15 @@ def run_migrations_online():
 
     """
     logging.info('Running migrations in online mode')
-    engine_config = {'sqlalchemy.url': get_db_url()}
-    connectable = engine_from_config(engine_config,
-                                     prefix="sqlalchemy.",
-                                     poolclass=pool.NullPool,
-                                     )
+    connectable = context.config.attributes.get("connection", None)
+
+    if connectable is None:
+        engine_config = {'sqlalchemy.url': get_db_url()}
+        connectable = engine_from_config(engine_config,
+                                         prefix="sqlalchemy.",
+                                         poolclass=pool.NullPool,
+                                         )
+
 
     with connectable.connect() as connection:
         context.configure(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-alembic

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,18 @@
+from pytest_alembic import tests, create_alembic_fixture
+
+# Due to the alembic config and migrations dir being in a non-standard location,
+# an alembic fixture with custom config is generated here:
+custom_alembic_fix = create_alembic_fixture({"file": "dbschema/alembic.ini", "script_location":"dbschema/migrations"})
+
+def test_single_head_revision(custom_alembic_fix):
+    tests.test_single_head_revision(custom_alembic_fix)
+
+def test_upgrade(custom_alembic_fix):
+    tests.test_upgrade(custom_alembic_fix)
+
+def test_model_definitions_match_ddl(custom_alembic_fix):
+    tests.test_model_definitions_match_ddl(custom_alembic_fix)
+
+def test_up_down_consistency(custom_alembic_fix):
+    tests.test_up_down_consistency(custom_alembic_fix)
+


### PR DESCRIPTION
Addresses part of https://github.com/PerfectFit-project/virtual-coach-issues/issues/283

This PR adds four `pytest-alembic` tests to check consistency of migrations against what is in `models.py`, among other upgrade/downgrade testing. This should, for example, catch situations when someone modifies `models.py` but forgets to generate (and commit) the corresponding migration).  In future we can add more custom tests to protect the prod db a bit better.